### PR TITLE
update various workflow's node-version to v.18

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -21,7 +21,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish --tag 24x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - node-version: '14'
+          - node-version: '18'
             docker-compose-file: 'docker-compose.ci.mysql.yml'
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish

--- a/README.md
+++ b/README.md
@@ -13,30 +13,13 @@ To regenerate, overwrite kbswagger.yaml and `npm run codegen && npm run build`
 
 Usage
 -
-``` javascript
-const killbill = require('killbill');
-const globalAxios = require('axios');
+See test cases under `test` directory.
 
-const axios = globalAxios.create();
-
-//optional - follow location header when new object is created
-axios.interceptors.response.use(killbill.followLocationHeaderInterceptor);
-
-//optional - configure tough cookie support
-const tough = require('tough-cookie');
-const axiosCookieJarSupport = require('axios-cookiejar-support').default;
-axiosCookieJarSupport(axios);
-axios.defaults.withCredentials = true;
-axios.defaults.jar = new tough.CookieJar();
-
-const config = new killbill.Configuration({
-    username: "admin"
-    password: "password",
-    apiKey: killbill.apiKey("bob", "lazar"),
-    basePath: "http://127.0.0.1:8080"
-});
-
-new killbill.AccountApi(config, null, axios).getAccountByKey("external_key")
-    .then(result => console.log(result))
-    .catch(error => console.log(error));
-```
+Release
+- 
+1. Update version in `package.json`
+2. Commit directly into `master` branch.
+3. Create git tag. Tag format is `v<version>`. For example, `v1.0.0`.
+4. Push the tag to remote.
+5. Go to https://github.com/killbill/killbill-client-js/releases/new, select the tag and fill in the release notes.
+6. Publish the release.


### PR DESCRIPTION
Try to fix [this problem](https://github.com/killbill/killbill-client-js/actions/runs/8593224756/job/23544409385#step:5:24). Why taking this action? Because of [this SO post](https://stackoverflow.com/questions/76421238/tsc-command-showing-syntaxerror-unexpected-token).

Update: This is the log, just in case the action log disappear:
```

> killbill@0.24.10 prepublishOnly .
> npm run build


> killbill@0.24.10 build /home/runner/work/killbill-client-js/killbill-client-js
> npm run clean && tsc


> killbill@0.24.10 clean /home/runner/work/killbill-client-js/killbill-client-js
> rm -rf dist

/home/runner/work/killbill-client-js/killbill-client-js/node_modules/typescript/lib/tsc.js:93
  for (let i = startIndex ?? 0; i < array.length; i++) {
                           ^

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/runner/work/killbill-client-js/killbill-client-js/node_modules/typescript/bin/tsc:2:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! killbill@0.24.10 build: `npm run clean && tsc`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the killbill@0.24.10 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2024-04-08T01_30_53_076Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! killbill@0.24.10 prepublishOnly: `npm run build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the killbill@0.24.10 prepublishOnly script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2024-04-08T01_30_53_094Z-debug.log
Error: Process completed with exit code 1.
```